### PR TITLE
Enhance slideDown function (add condition)

### DIFF
--- a/src/slide.js
+++ b/src/slide.js
@@ -55,7 +55,8 @@ export function slideUp(target, duration = 500, fn){
  */
 export function slideDown(target, duration = 500, fn){
     // not reset if is already open
-    if(parseInt(getElementHeight(target)) === 0){
+    // check display:none because sometimes the browser has a wrong calculation of target's height when it is visible!
+    if(parseInt(getElementHeight(target)) === 0 || target.style.display.trim() === 'none'){
         // before
         setCSS(target, {
             boxSizing: 'border-box',


### PR DESCRIPTION
When the element is visible (display: none) and then we opened it -> the condition in **slideDown** function has a wrong calculation of its height (image below). So, we can't have an override value on **display** property. So it doesn't work!!

![image](https://user-images.githubusercontent.com/30406982/192971517-4d812f8d-de03-4573-bab9-0d67d461987e.png)

Solution:
- I have written a small condition to check whenever the height of the element is equal to zero **OR** the display attribute of this element is "none" -> we will run the statement in conditions scope.

I have checked it, and it works.
