### PR TITLE
Fix minus active section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Easy Tab & Accordion (ETA) v2.0.2
+# Easy Tab & Accordion (ETA)
 
 [![release](https://badgen.net/github/release/viivue/easy-tab-accordion/)](https://github.com/viivue/easy-tab-accordion/releases/latest)
 [![minified](https://badgen.net/badge/minified/10KB/cyan)](https://www.jsdelivr.com/package/gh/viivue/easy-tab-accordion)
@@ -12,7 +12,7 @@
 
 ### Download
 
-👉 Self hosted - [Download latest release](https://github.com/viivue/easy-tab-accordion/releases/latest)
+👉 Self hosted - [Download the latest release](https://github.com/viivue/easy-tab-accordion/releases/latest)
 
 ```html
 

--- a/src/easy-tab-accordion.js
+++ b/src/easy-tab-accordion.js
@@ -51,6 +51,11 @@ export class EasyTabAccordion{
         // setup
         this.setupData();
 
+        if(this.count < 1){
+            log(this, 'warn', 'Quit init due to child panels not found', this);
+            return;
+        }
+
         // init
         if(this.enabled && !this.hasInitialized) this.init();
         if(!this.enabled && this.hasInitialized) this.destroy();

--- a/src/slide.js
+++ b/src/slide.js
@@ -15,6 +15,7 @@ export function slideUp(target, duration = 500, fn){
     if(height === '0px'){
         // callback
         if(typeof fn === 'function') fn();
+        return;
     }
 
     // before

--- a/src/slide.js
+++ b/src/slide.js
@@ -12,7 +12,10 @@ import {removeActiveClass} from "./helpers";
 export function slideUp(target, duration = 500, fn){
     // skip if already closed
     const height = getElementHeight(target);
-    if(height === '0px') return;
+    if(height === '0px'){
+        // callback
+        if(typeof fn === 'function') fn();
+    }
 
     // before
     setCSS(target, {


### PR DESCRIPTION
Lose callback of `slideUp()` causes missing events. See https://github.com/viivue/easy-tab-accordion/pull/18/commits/607ec83bea006b61ca4ad80dcac67fbbf9d6ebbc