### PR TITLE
getOptions > refactor code for reuse through multiple ESLibs

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -121,7 +121,7 @@ export class EasyTabAccordion{
         this.options.animation = animationValue !== null ? animationValue : this.options.animation;
 
         // get options init by data attribute (JSON format)
-        this.options = getOptions(this, this.options);
+        this.options = getOptions(this);
 
         // assign id to wrapper
         this.wrapper.setAttribute(this._attr.container, this.id);

--- a/src/_index.js
+++ b/src/_index.js
@@ -121,7 +121,7 @@ export class EasyTabAccordion{
         this.options.animation = animationValue !== null ? animationValue : this.options.animation;
 
         // get options init by data attribute (JSON format)
-        getOptions(this);
+        this.options = getOptions(this, this.options);
 
         // assign id to wrapper
         this.wrapper.setAttribute(this._attr.container, this.id);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -232,9 +232,6 @@ export function getOptions(context, defaultOptions){
 
     options = {...defaultOptions, ...options};
 
-    // remove json
-    wrapper.removeAttribute(context._attr.container);
-
     return options;
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -205,24 +205,25 @@ export function getOptions(context, defaultOptions){
     let options = {};
 
     // data attribute doesn't exist or not JSON format -> string
-    if(!dataAttribute || !isJSON(dataAttribute)){
-        // reassign id
-        const id = dataAttribute || wrapper.id || defaultOptions.id;
-        context.id = id;
-        defaultOptions.id = id;
+    const attributeIsNotJSON = !dataAttribute || !isJSON(dataAttribute);
 
-        return defaultOptions;
-    }
+    // data attribute is not json format or string
+    if(attributeIsNotJSON){
+        options = defaultOptions;
 
-    options = JSON.parse(dataAttribute);
+        // data attribute exist => string
+        if(dataAttribute) options.id = dataAttribute;
+    }else{
+        options = JSON.parse(dataAttribute);
 
-    for(const [key, value] of Object.entries(options)){
-        // convert boolean string to real boolean
-        if(value === "false") options[key] = false;
-        else if(value === "true") options[key] = true;
-        // convert string to float
-        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
-        else options[key] = value;
+        for(const [key, value] of Object.entries(options)){
+            // convert boolean string to real boolean
+            if(value === "false") options[key] = false;
+            else if(value === "true") options[key] = true;
+            // convert string to float
+            else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+            else options[key] = value;
+        }
     }
 
     // reassign id

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -240,9 +240,10 @@ export function getOptions(context, defaultOptions){
 
 
 /**
- * Get ID
+ * Is JSON string
+ * https://stackoverflow.com/a/32278428/6453822
  * @param string
- * @returns void
+ * @returns {any|boolean}
  */
 function isJSON(string){
     try{

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -195,34 +195,39 @@ export function log(context, status, ...message){
  * @returns void
  */
 export function getOptions(context){
+    const numeric = ['duration', 'activeSection']; // convert these props to float
+    const wrapper = context.wrapper;
+
     // options from attribute
-    let string = context.wrapper.getAttribute(context._attr.container);
+    let dataAttribute = wrapper.getAttribute(context._attr.container);
     let options = {};
 
-    if(!isJSON(string)){
-        context.id = context.options.id;
+    // data attribute doesn't exist or not JSON format -> get default ID
+    if(!dataAttribute || !isJSON(dataAttribute)){
+        context.id = dataAttribute || context.options.id;
         return;
     }
 
     // option priority: attribute > js object > default
-    options = {...JSON.parse(string)};
+    options = JSON.parse(dataAttribute);
 
-    // convert boolean string to real boolean
     for(const [key, value] of Object.entries(options)){
+        // convert boolean string to real boolean
         if(value === "false") options[key] = false;
-        if(value === "true") options[key] = true;
-        if(!isNaN(value)) options[key] = parseInt(value);
+        else if(value === "true") options[key] = true;
+        else options[key] = value;
+
+        // convert string to float
+        if(numeric.includes(key) && typeof value === 'string' && value.length > 0){
+            options[key] = parseFloat(value);
+        }
     }
 
-    // get ID
-    if(options['id'] && !isEmptyString(options['id'])){
-        context.id = options['id'];
-    }else{
-        context.id = context.options.id;
-    }
-
-    // replace default options
     context.options = {...context.options, ...options};
+    context.id = options.id || context.options.id;
+
+    // remove json
+    wrapper.removeAttribute(context._attr.container);
 }
 
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -197,6 +197,10 @@ export function log(context, status, ...message){
  * @returns {object}
  */
 export function getOptions(context, defaultOptions){
+    if(!defaultOptions){
+        defaultOptions = context.options || context.config || {};
+    }
+
     const numeric = ['duration', 'activeSection']; // convert these props to float
     const wrapper = context.wrapper;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -192,6 +192,7 @@ export function log(context, status, ...message){
 
 /**
  * Get JSON options
+ * @version 0.0.1
  * @returns void
  */
 export function getOptions(context){

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -220,12 +220,9 @@ export function getOptions(context, defaultOptions){
         // convert boolean string to real boolean
         if(value === "false") options[key] = false;
         else if(value === "true") options[key] = true;
-        else options[key] = value;
-
         // convert string to float
-        if(numeric.includes(key) && typeof value === 'string' && value.length > 0){
-            options[key] = parseFloat(value);
-        }
+        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+        else options[key] = value;
     }
 
     // reassign id

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -204,7 +204,7 @@ export function getOptions(context, defaultOptions){
     let dataAttribute = wrapper.getAttribute(context._attr.container);
     let options = {};
 
-    // data attribute doesn't exist or not JSON format -> get default ID
+    // data attribute doesn't exist or not JSON format -> string
     if(!dataAttribute || !isJSON(dataAttribute)){
         // reassign id
         const id = dataAttribute || wrapper.id || defaultOptions.id;
@@ -214,7 +214,6 @@ export function getOptions(context, defaultOptions){
         return defaultOptions;
     }
 
-    // option priority: attribute > js object > default
     options = JSON.parse(dataAttribute);
 
     for(const [key, value] of Object.entries(options)){
@@ -229,12 +228,12 @@ export function getOptions(context, defaultOptions){
         }
     }
 
-    options = {...defaultOptions, ...options};
-
     // reassign id
     const id = options.id || wrapper.id || defaultOptions.id;
     context.id = id;
     options.id = id;
+
+    options = {...defaultOptions, ...options};
 
     // remove json
     wrapper.removeAttribute(context._attr.container);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -192,10 +192,11 @@ export function log(context, status, ...message){
 
 /**
  * Get JSON options
+ * ID priority: data-attribute > selector#id > unique id
  * @version 0.0.1
- * @returns void
+ * @returns {object}
  */
-export function getOptions(context){
+export function getOptions(context, defaultOptions){
     const numeric = ['duration', 'activeSection']; // convert these props to float
     const wrapper = context.wrapper;
 
@@ -205,8 +206,12 @@ export function getOptions(context){
 
     // data attribute doesn't exist or not JSON format -> get default ID
     if(!dataAttribute || !isJSON(dataAttribute)){
-        context.id = dataAttribute || context.options.id;
-        return;
+        // reassign id
+        const id = dataAttribute || wrapper.id || defaultOptions.id;
+        context.id = id;
+        defaultOptions.id = id;
+
+        return defaultOptions;
     }
 
     // option priority: attribute > js object > default
@@ -224,19 +229,24 @@ export function getOptions(context){
         }
     }
 
-    context.options = {...context.options, ...options};
-    context.id = options.id || context.options.id;
+    options = {...defaultOptions, ...options};
+
+    // reassign id
+    const id = options.id || wrapper.id || defaultOptions.id;
+    context.id = id;
+    options.id = id;
 
     // remove json
     wrapper.removeAttribute(context._attr.container);
+
+    return options;
 }
 
 
 /**
- * Is JSON string
- * https://stackoverflow.com/a/32278428/6453822
+ * Get ID
  * @param string
- * @returns {any|boolean}
+ * @returns void
  */
 function isJSON(string){
     try{


### PR DESCRIPTION
Write the same `getOptions` function for making our code reusable and using through multiple ES Libraries (or any library that needs to get options from data-attribute) :
- [Easy Tab Accordion](https://github.com/viivue/easy-tab-accordion)
- [Easy Select](https://github.com/viivue/easy-select)
- [Easy Popup](https://github.com/viivue/easy-popup)

With the new `getOptions` function, we can get options and override them for each library option through data-attribute