### PR TITLE
getOptions > minor bug when cloning default options

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -213,10 +213,11 @@ export function getOptions(context, defaultOptions){
 
     // data attribute is not json format or string
     if(attributeIsNotJSON){
-        options = defaultOptions;
+        options = {...defaultOptions};
 
         // data attribute exist => string
         if(dataAttribute) options.id = dataAttribute;
+        else options.id = '';
     }else{
         options = JSON.parse(dataAttribute);
 


### PR DESCRIPTION
In the previous version of the `getOptions` function, we got some bugs because I didn't clone the default options, I referred the current options to it. So I have fixed it. Please check again! Thank you.