### PR TITLE
Add hasActivatedSection flag

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -141,6 +141,9 @@ export class EasyTabAccordion{
         if(this.enabled && !this.hasInitialized) initSetup(this);
         if(!this.enabled && this.hasInitialized) this.destroy();
 
+        // activated flag
+        this.hasActivatedSection = false;
+
         // toggle via hash
         if(this.enabled){
             if(isValidHash(this)){
@@ -149,6 +152,8 @@ export class EasyTabAccordion{
                 defaultActiveSections(this);
             }
         }
+
+        this.hasActivatedSection = true;
 
         // watch for resize/load events
         window.addEventListener('resize', debounce(e => onResize(this, e), 300));

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -27,7 +27,7 @@ export function getToggleState(context, id){
     // exit: 0
 
     // check if option is avoid double click
-    if(context.options.avoidDoubleClick){
+    if(context.options.avoidDoubleClick && context.hasActivatedSection){
         if(context.isAnimating){
             log(context, 'warn', `Block [${id}] to avoid double click on animating item.`);
             return 0;


### PR DESCRIPTION
## Problem
- We are unable to open multiple sections (`activeSections`) in the array.

## Why
![image](https://user-images.githubusercontent.com/30406982/231701893-663e1435-94e7-4a9b-88a8-eb6fc41a9736.png)
We have a condition for blocking  to avoid the double click on the animating item, but we need to escape that condition if we input `activeSections` in the array by default

## Problem
- Add `hasActivated` flag for checking it in `getToggleState` function.
