### PR TITLE
Show multiple items when initialize

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -142,7 +142,7 @@ export class EasyTabAccordion{
         if(!this.enabled && this.hasInitialized) this.destroy();
 
         // activated flag
-        this.hasActivatedSection = false;
+        this.hasInitializedActiveSections = false;
 
         // toggle via hash
         if(this.enabled){
@@ -153,7 +153,7 @@ export class EasyTabAccordion{
             }
         }
 
-        this.hasActivatedSection = true;
+        this.hasInitializedActiveSections = true;
 
         // watch for resize/load events
         window.addEventListener('resize', debounce(e => onResize(this, e), 300));

--- a/src/_index.js
+++ b/src/_index.js
@@ -6,7 +6,7 @@ import {
     getToggleState,
     getIndexById,
     getElements,
-    removeActiveClass, addActiveClass, getIdByIndex, defaultActiveSections, log, getOptions
+    removeActiveClass, addActiveClass, getIdByIndex, log, getOptions
 } from "./helpers";
 import {debounce, uniqueId} from "./utils";
 import {initSetup, onLoad, onResize} from "./methods";

--- a/src/_index.js
+++ b/src/_index.js
@@ -141,6 +141,9 @@ export class EasyTabAccordion{
         if(this.enabled && !this.hasInitialized) initSetup(this);
         if(!this.enabled && this.hasInitialized) this.destroy();
 
+        // activated flag
+        this.hasActivatedSection = false;
+
         // toggle via hash
         if(this.enabled){
             if(isValidHash(this)){
@@ -149,6 +152,8 @@ export class EasyTabAccordion{
                 defaultActiveSections(this);
             }
         }
+
+        this.hasActivatedSection = true;
 
         // watch for resize/load events
         window.addEventListener('resize', debounce(e => onResize(this, e), 300));

--- a/src/_index.js
+++ b/src/_index.js
@@ -141,20 +141,6 @@ export class EasyTabAccordion{
         if(this.enabled && !this.hasInitialized) initSetup(this);
         if(!this.enabled && this.hasInitialized) this.destroy();
 
-        // activated flag
-        this.hasInitializedActiveSections = false;
-
-        // toggle via hash
-        if(this.enabled){
-            if(isValidHash(this)){
-                this.toggle(getHash().id, 'hash');
-            }else{
-                defaultActiveSections(this);
-            }
-        }
-
-        this.hasInitializedActiveSections = true;
-
         // watch for resize/load events
         window.addEventListener('resize', debounce(e => onResize(this, e), 300));
         window.addEventListener('load', e => onLoad(this, e));

--- a/src/_index.js
+++ b/src/_index.js
@@ -1,6 +1,6 @@
 import {slideDown, slideUp, destroySlide, updateSlide} from "./slide";
 import {fadeIn, fadeOut, destroyFade, updateFade} from "./fade";
-import {getHash, isValidHash, hashScroll, updateURL} from "./hash";
+import {hashScroll, updateURL} from "./hash";
 import {
     validID,
     getToggleState,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -27,7 +27,7 @@ export function getToggleState(context, id){
     // exit: 0
 
     // check if option is avoid double click
-    if(context.options.avoidDoubleClick && context.hasActivatedSection){
+    if(context.options.avoidDoubleClick && context.hasInitializedActiveSections){
         if(context.isAnimating){
             log(context, 'warn', `Block [${id}] to avoid double click on animating item.`);
             return 0;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -27,7 +27,7 @@ export function getToggleState(context, id){
     // exit: 0
 
     // check if option is avoid double click
-    if(context.options.avoidDoubleClick){
+    if(context.options.avoidDoubleClick && context.hasActivatedSection){
         if(context.isAnimating){
             log(context, 'warn', `Block [${id}] to avoid double click on animating item.`);
             return 0;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,10 +24,12 @@ export function getToggleState(context, id){
     if(!validID(context, id)) return false;
     // close: -1
     // open: 1
-    // exit: 0
+    // exit: 0 // prevent open or close
 
-    // check if option is avoid double click
-    if(context.options.avoidDoubleClick && context.hasInitializedActiveSections){
+    // exit if it is animating, and
+    // when has not initialized, allow to run multiple animation due to possible multiple active sections
+    if(context.hasInitialized && context.options.avoidDoubleClick){
+        // avoid multiple animation at the same time
         if(context.isAnimating){
             log(context, 'warn', `Block [${id}] to avoid double click on animating item.`);
             return 0;

--- a/src/methods.js
+++ b/src/methods.js
@@ -59,11 +59,11 @@ export function initSetup(context){
         }
     }
 
-    // event: onAfterInit
-    context.options.onAfterInit(context);
-
     // initialized flag
     context.hasInitialized = true;
+
+    // event: onAfterInit
+    context.options.onAfterInit(context);
 }
 
 function assignTriggerElements(context){

--- a/src/methods.js
+++ b/src/methods.js
@@ -1,12 +1,12 @@
 import {responsive} from "./responsive";
 import {setCSS, setTransition} from "./animation";
-import {getHash} from "./hash";
+import {getHash, isValidHash} from "./hash";
+import {defaultActiveSections} from "./helpers";
 
 export function initSetup(context){
     // event: onBeforeInit
     context.options.onBeforeInit(context);
 
-    context.hasInitialized = true;
     context.wrapper.classList.add(context._class.enabled);
 
     // loop through triggers
@@ -50,8 +50,20 @@ export function initSetup(context){
 
     assignTriggerElements(context);
 
+    // toggle via hash
+    if(context.enabled){
+        if(isValidHash(context)){
+            context.toggle(getHash().id, 'hash');
+        }else{
+            defaultActiveSections(context);
+        }
+    }
+
     // event: onAfterInit
     context.options.onAfterInit(context);
+
+    // initialized flag
+    context.hasInitialized = true;
 }
 
 function assignTriggerElements(context){


### PR DESCRIPTION
## Problem
- We are unable to open multiple sections (`activeSections`) in the array.

## Why
![image](https://user-images.githubusercontent.com/30406982/231701893-663e1435-94e7-4a9b-88a8-eb6fc41a9736.png)
We have a condition for blocking  to avoid the double click on the animating item, but we need to escape that condition if we input `activeSections` in the array by default

## Problem
- Add `hasActivated` flag for checking it in `getToggleState` function.
