### PR TITLE
fix: missing options from html attr

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -171,7 +171,7 @@
 
     <h2 class="heading-separator"><span>Accordion initialize with JSON format</span></h2>
 
-    <div data-eta='{ "id":"my-id", "animation":"slide", "hash":"false", "duration":"1000", "isPreventDefault": "true"}'>
+    <div data-eta='{ "id":"init-with-json", "animation":"slide", "hash":"false", "duration":"1000", "isPreventDefault": "true"}'>
         <!-- section 1 -->
         <div>
             <a href="https://github.com" target="_blank" data-eta-trigger="section-1">Section 1</a>

--- a/src/_index.js
+++ b/src/_index.js
@@ -8,7 +8,7 @@ import {
     getElements,
     removeActiveClass, addActiveClass, getIdByIndex, log
 } from "./helpers";
-import {debounce} from "./utils";
+import {debounce, uniqueId} from "./utils";
 import {initSetup, onLoad, onResize} from "./methods";
 import {isLive, validBreakpoints} from "./responsive";
 import {scrollIntoView} from "./animation";
@@ -17,22 +17,25 @@ import {EventsManager, getOptionsFromAttribute} from "@phucbm/os-util";
 
 export class EasyTabAccordion{
     constructor(options){
+        // update options
+        this.options = {...DEFAULTS, id: uniqueId('eta-'), ...options};
+        if(!this.options.el){
+            log(this, 'warn', 'ETA Error, target not found!');
+            return;
+        }
+
+        // get options init by data attribute (JSON format)
+        this.options = getOptionsFromAttribute({
+            target: this.options.el,
+            defaultOptions: this.options,
+            attributeName: ATTRS.container,
+            numericValues: ['duration', 'activeSection'],
+            dev: true,// DEFAULTS.dev
+        });
+
         // init events manager
         this.events = new EventsManager(this, {
             names: ['onBeforeInit', 'onAfterInit', 'onBeforeOpen', 'onBeforeClose', 'onAfterOpen', 'onAfterClose', 'onDestroy', 'onUpdate'],
-        })
-
-        // save options
-        this.originalOptions = options;
-
-        // get options init by data attribute (JSON format)
-        this.options
-            = getOptionsFromAttribute({
-            target: this.wrapper,
-            defaultOptions: {...DEFAULTS, ...options},
-            attributeName: ATTRS.container,
-            numericValues: ['duration', 'activeSection'],
-            dev: DEFAULTS.dev
         });
 
         // init
@@ -53,11 +56,6 @@ export class EasyTabAccordion{
     };
 
     init(){
-        if(!this.options.el){
-            log(this, 'warn', 'ETA Error, target not found!');
-            return;
-        }
-
         this.wrapper = this.options.el;
         this.id = this.options.id;
         this.current_id = '';

--- a/src/configs.js
+++ b/src/configs.js
@@ -24,8 +24,8 @@ export const ATTRS = {
  * */
 export const DEFAULTS = {
     // selectors
-    el: document.querySelector('[data-eta]'), // DOM element
-    id: uniqueId('eta-'),
+    el: undefined, // DOM element
+    id: undefined,
     trigger: '[data-eta-trigger]', // string selector
     triggerAttr: 'data-eta-trigger', // attribute name
     receiver: '[data-eta-receiver]', // string selector


### PR DESCRIPTION
This bug happened after #46, the `target` is undefined.