### PR TITLE
feat(options): fit option allowCollapseAll working not correct.

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -297,6 +297,11 @@ export class EasyTabAccordion{
         const toggleState = getToggleState(this, id);
         if(toggleState === 0) return;
 
+        // check can close all.
+        const countOtherOpen = this.dataset.reduce((c, item) => (item.active && item.id !== id ? ++c : c), 0);
+        const allowCloseAll = this.options.animation === 'slide' && this.options.allowCollapseAll;
+        if (toggleState === -1 && countOtherOpen <= 0 && !allowCloseAll) return;
+
         // start animation
         this.isAnimating = true;
         log(this, 'log', 'Start animation.');

--- a/src/_index.js
+++ b/src/_index.js
@@ -298,7 +298,7 @@ export class EasyTabAccordion{
         if(toggleState === 0) return;
 
         // check can close all.
-        const countOtherOpen = this.dataset.reduce((c, item) => (item.active && item.id !== id ? ++c : c), 0);
+        const countOtherOpen = this.dataset.reduce((c, item) => (item.active && item.id !== id ? c + 1 : c), 0);
         const allowCloseAll = this.options.animation === 'slide' && this.options.allowCollapseAll;
         if (toggleState === -1 && countOtherOpen <= 0 && !allowCloseAll) return;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -36,24 +36,12 @@ export function getToggleState(context, id){
     }
 
     const open = context.dataset[getPanelIndexById(context, id)].active;
-    const allowCollapseAll = context.options.animation === 'slide' ? context.options.allowCollapseAll : false;
 
     // is open and is fade => do nothing
     if(open && context.options.animation === 'fade') return 0;
 
-    // is open and allow collapse all => close
-    if(open && allowCollapseAll) return -1;
-
-    // is open and not allow collapse all => close
-    if(open && !allowCollapseAll) return -1;
-
-    // is close and allow collapse all => open
-    if(!open && allowCollapseAll) return 1;
-
-    // is close and not allow collapse all => open
-    if(!open && !allowCollapseAll) return 1;
-
-    return open ? 1 : -1;
+    // return -1 if open, 1 if close, (return next state base on current state)
+    return open ? -1 : 1;
 }
 
 


### PR DESCRIPTION
This pr fix option of accordion `allowCollapseAll` not working as expected.
Currently, option `allowCollapseAll` not working although default value is false, but in demo we still can collapse all tab accordions.

In demo: https://easy-tab-accordion.netlify.app/
<img width="1162" height="545" alt="image" src="https://github.com/user-attachments/assets/7d52336a-80dd-4095-a9b9-c2cc1f9590cf" />

As image, we can collapse either 2 accordions.

But in this image note: default of `allowCollapseAll` is `false` so this current behaving is not correct.
<img width="921" height="171" alt="image" src="https://github.com/user-attachments/assets/ef1b98c5-0863-47bc-9c96-a41a61a934ec" />


How to fix. 
- in file `helper.js`, in function `getToggleState` this is old codes: 

<img width="948" height="388" alt="image" src="https://github.com/user-attachments/assets/2d53b9ae-d9c7-4f20-b711-406f569d361d" />

As we can see in image, despite value of `allowCollapseAll` is true or false, we always return `-1` when `open` is true (meaning next state is close). So tab can collapse all no matter value of `allowCollapseAll` is true or false.
The same when `open` is false (current is close), it will always return 1.

- this is after fix in function `getToggleState`. 

<img width="674" height="154" alt="image" src="https://github.com/user-attachments/assets/4fd8f3bb-d13d-4aed-882d-d3def5c8363a" />

Function `getToggleState` will return next state of tab, example if current is close then return 1 (next is open).

Next change is in `_index.js` file. In function `toggle`

<img width="798" height="99" alt="image" src="https://github.com/user-attachments/assets/8f8e3df4-a254-4c7a-ae53-876ee46f1ce5" />

We will check if we can collapse all in this function. 
NOTE: `this.options.animation === 'slide'` is for accordion if `this.options.animation === 'fade'` then it is tabs display.
